### PR TITLE
Fix for mq shoveling config bug

### DIFF
--- a/localega/conf/mq.sh
+++ b/localega/conf/mq.sh
@@ -33,7 +33,7 @@ chmod 640 /etc/rabbitmq/defs.json
 cat > /etc/rabbitmq/defs-cega.json <<EOF
 {"parameters":[{"value": {"src-uri": "amqp://",
 				"src-exchange": "cega",
-				"src-exchange-key": "",
+				"src-exchange-key": "#",
 				"dest-uri": "${CEGA_CONNECTION}",
 				"dest-exchange": "localega.v1",
 				"add-forward-headers": false,


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
This PR address an small but urgent bug, that prevents the message being forwarded to the CEGA MQ upon file ingestion. This can be replicated by trying to ingest a file and observing how before this fix the message is not forwarded to CEGA, and after the bug fix that the message is forwarded

### Changes made:
1. `mq.sh` restored as it was with the `src-exchange-key` in the original configuration https://github.com/EGA-archive/LocalEGA/blob/master/deploy/images/mq/entrypoint.sh#L35

### Additional information:

> Can we have tests for this ?

Work in progress, but yes there is a script I am using for automating and testing the ingestion.

### Related Issues:

https://github.com/EGA-archive/LocalEGA/issues/7