### PR TITLE
Add type NodePort to SVC in Inbox

### DIFF
--- a/ega-charts/localega/Chart.yaml
+++ b/ega-charts/localega/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: localega
 sources:
 - https://github.com/NBISweden/LocalEGA-helm
-version: 0.2.3
+version: 0.2.4

--- a/ega-charts/localega/templates/inbox-svc.yaml
+++ b/ega-charts/localega/templates/inbox-svc.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: {{ template "localega.name" . }}-inbox
 spec:
+  type: "{{ .Values.inbox.service.type }}"
   ports:
     - name: inbox
       port: {{ .Values.inbox.service.port }}


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
Prevents the following failure if one wants to specify `NodePort` to `Inbox` (unless I missed something):
```
╰─$ helm install --name lega --namespace lega localega -f localega/values.yaml -f localega/config/trace.yml
Error: release lega failed: Service "lega-localega-inbox" is invalid: spec.ports[0].nodePort: Forbidden: may not be used when `type` is 'ClusterIP'
```

