### PR TITLE
Address DB health checks and e2e logging

### DIFF
--- a/ega-charts/localega/Chart.yaml
+++ b/ega-charts/localega/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
 name: localega
 sources:
 - https://github.com/NBISweden/LocalEGA-helm
-version: 0.2.4
+version: 0.2.5

--- a/ega-charts/localega/templates/e2e-tester.yaml
+++ b/ega-charts/localega/templates/e2e-tester.yaml
@@ -86,6 +86,9 @@ spec:
       - name: e2e-tester
         image: "{{ .Values.tester.repository }}:{{ .Values.tester.imageTag }}"
         imagePullPolicy: {{ .Values.tester.imagePullPolicy | quote }}
+        env:
+          - name: DEFAULT_LOG
+            value: {{ .Values.tester.log | quote }}
         livenessProbe:
           exec:
             command:

--- a/ega-charts/localega/templates/inbox-deploy.yaml
+++ b/ega-charts/localega/templates/inbox-deploy.yaml
@@ -69,8 +69,11 @@ spec:
           containerPort: 9000
           protocol: TCP
         readinessProbe:
-          tcpSocket:
-            port: inbox
+          exec:
+            command:
+            - sh
+            - -ec
+            - ps -ef | grep ega-sshd
           initialDelaySeconds: 30
           periodSeconds: 15
         volumeMounts:

--- a/ega-charts/localega/templates/postgres-sts.yaml
+++ b/ega-charts/localega/templates/postgres-sts.yaml
@@ -58,7 +58,7 @@ spec:
             - -h
             - localhost
             - -U
-            - {{ .Values.config.postgres_user}}
+            - {{ .Values.config.postgres_in_user}}
           initialDelaySeconds: 30
           timeoutSeconds: 5
         readinessProbe:
@@ -68,7 +68,7 @@ spec:
             - -h
             - localhost
             - -U
-            - {{ .Values.config.postgres_user}}
+            - {{ .Values.config.postgres_in_user}}
           initialDelaySeconds: 5
           timeoutSeconds: 1
       {{- if .Values.postgres.metrics.enabled }}

--- a/ega-charts/localega/values.yaml
+++ b/ega-charts/localega/values.yaml
@@ -266,6 +266,7 @@ verify:
 tester:
   run: false
   name: tester
+  log: "debug"
   repository: nbisweden/localega-tester
   imageTag: release.v0.0.1
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [x] Functional change

### Pull request long description:
DB health checks were failing:
```
2019-04-25 13:21:44.844 UTC [58] DETAIL:  Role "root" does not exist.
    Connection matched pg_hba.conf line 3: "hostssl  all         all       127.0.0.1/32   scram-sha-256"
2019-04-25 13:21:54.846 UTC [64] FATAL:  password authentication failed for user "root"
```
thus a right user needed to be used.

Readiness probe was failing for OpenSSH inbox as described by #35 and this was addressed by checking a certain process is running.

Also addressing this feature: https://github.com/NBISweden/LocalEGA-tester/pull/19

### Changes made:
1. changed  the `.Values.config.postgres_user`  to `.Values.config.postgres_in_user`
2. added `log: "debug"` to `tester`
3. added `DEFAULT_VALUE` env var to e2e template
4. Fix readiness probe for OpenSSH inbox
5. bump chart to `0.2.5`

### Related issues:
Fixes #33 
Fixes #35 

Addresses changes needed for https://github.com/NBISweden/LocalEGA-tester/pull/19

### Mentions 
I know we should not make many changes into one PR, but these are minor and it will be inconvenient to increment all the time the version for these minor changes.