### PR TITLE
FileStorage backend for Data Archive.

### DIFF
--- a/ega-charts/localega/templates/e2e-tester.yaml
+++ b/ega-charts/localega/templates/e2e-tester.yaml
@@ -131,6 +131,18 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         allowPrivilegeEscalation: false
+    {{- if .Values.res.coLocateIngest }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: role
+                operator: In
+                values:
+                - ingest
+            topologyKey: "kubernetes.io/hostname"
+    {{- end }}
       containers:
       - name: e2e-tester
         image: "{{ .Values.tester.repository }}:{{ .Values.tester.imageTag }}"
@@ -154,6 +166,10 @@ spec:
           mountPath: /conf
         - name: file-download
           mountPath: /volume
+      {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+          mountPath: /ega/archive
+      {{- end }}
       restartPolicy: Never
       volumes:
         - name: file-download
@@ -191,4 +207,30 @@ spec:
                   path: tester.ca.crt
                 - key: tester.ca.key
                   path: tester.ca.key
+      {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+        {{- if and .Values.persistence.enabled .Values.podSecurityPolicy.create }}
+          {{- if .Values.ingest.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.ingest.persistence.existingClaim }}
+          {{- else if (eq "flexVolume" .Values.ingest.persistence.storageClass) }}
+          flexVolume:
+            driver: {{ .Values.ingest.persistence.flexVolume.driver | quote }}
+            fsType: {{ .Values.ingest.persistence.flexVolume.fsType | quote }}
+            options:
+              fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
+              clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
+          {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
+          source:
+            nfs:
+              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
+              readOnly: false
+          {{- end }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.config.data_storage_location | quote }}
+            type: Directory
+        {{- end }}
+      {{- end }}
 {{- end }}

--- a/ega-charts/localega/templates/ingest-deploy.yaml
+++ b/ega-charts/localega/templates/ingest-deploy.yaml
@@ -78,6 +78,10 @@ spec:
           mountPath: "/etc/ega/ssl"
         - name: conf
           mountPath: /etc/ega/
+        {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+          mountPath: "/ega/archive"
+        {{- end }}
       restartPolicy: Always
       volumes:
       - name: tls
@@ -93,26 +97,52 @@ spec:
             - configMap:
                 name: {{ template "localega.name" . }}-ingest-conf
       - name: lega-inbox
-      {{- if and .Values.persistence.enabled }}
-        {{- if .Values.inbox.persistence.existingClaim }}
+{{- if and .Values.persistence.enabled .Values.podSecurityPolicy.create }}
+      {{- if .Values.inbox.persistence.existingClaim }}
         persistentVolumeClaim:
           claimName: {{ if .Values.inbox.persistence.existingClaim }}{{ .Values.inbox.persistence.existingClaim }}{{ else }}{{ template "localega.inbox.fullname" . }}{{ end }}
-        {{- else if (eq "flexVolume" .Values.inbox.persistence.storageClass) }}
+      {{- else if (eq "flexVolume" .Values.inbox.persistence.storageClass) }}
         flexVolume:
           driver: {{ .Values.inbox.persistence.flexVolume.driver | quote }}
           fsType: {{ .Values.inbox.persistence.flexVolume.fsType | quote }}
           options:
             fsName: {{ .Values.inbox.persistence.flexVolume.fsName | quote }}
             clusterNamespace:  {{ .Values.inbox.persistence.flexVolume.clusterNamespace | quote }}
-        {{- else if (eq "nfs" .Values.inbox.persistence.storageClass) }}
+      {{- else if (eq "nfs" .Values.inbox.persistence.storageClass) }}
         source:
           nfs:
             server: {{ if .Values.inbox.persistence.nfs.server }}{{ .Values.inbox.persistence.nfs.server | quote }}{{ end }}
             path: {{ if .Values.inbox.persistence.nfs.path }}{{ .Values.inbox.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
             readOnly: false
-        {{- end }}
-      {{- else if (not .Values.podSecurityPolicy.create ) }}
+      {{- end }}
+  {{- if eq "FileStorage" .Values.config.data_storage_type }}
+      - name: lega-archive
+      {{- if .Values.ingest.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.ingest.persistence.existingClaim }}
+      {{- else if (eq "flexVolume" .Values.ingest.persistence.storageClass) }}
+        flexVolume:
+          driver: {{ .Values.ingest.persistence.flexVolume.driver | quote }}
+          fsType: {{ .Values.ingest.persistence.flexVolume.fsType | quote }}
+          options:
+            fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
+            clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
+      {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
+        source:
+          nfs:
+            server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+            path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
+            readOnly: false
+      {{- end }}
+  {{- end }}
+{{- else }}
         hostPath:
           path: {{ .Values.inbox.location | quote }}
           type: Directory
-      {{- end }}
+  {{- if eq "FileStorage" .Values.config.data_storage_type }}
+      - name: lega-archive
+        hostPath:
+          path: {{ .Values.config.data_storage_location | quote }}
+          type: Directory
+  {{- end }}
+{{- end }}

--- a/ega-charts/localega/templates/res-deploy.yaml
+++ b/ega-charts/localega/templates/res-deploy.yaml
@@ -52,7 +52,7 @@ spec:
 {{ toYaml .Values.res.resources | trim | indent 10 }}
         env:
         - name: SPRING_PROFILES_ACTIVE
-          value: no-oss,LocalEGA
+          value: {{ if eq "FileStorage" .Values.config.data_storage_type }} no-oss,default {{ else }} no-oss,LocalEGA {{ end }}
         - name: FILEDATABASE_SERVERS
           value: "{{ template "localega.name" . }}-filedatabase:{{ .Values.filedatabase.servicePort }}"
         - name: KEYS_SERVERS
@@ -73,6 +73,7 @@ spec:
           value:
         - name: EGA_SHAREDPASS_PATH
           value: /etc/ega/shared.pass
+        {{- if eq "S3Storage" .Values.config.data_storage_type }}
         - name: EGA_EBI_AWS_ENDPOINT_URL
           value: {{ required "A valid .Values.config.data_storage_url entry required!" .Values.config.data_storage_url | quote }}
         - name: EGA_EBI_AWS_ACCESS_KEY
@@ -87,6 +88,7 @@ spec:
                 key: s3_secret_key
         - name: EGA_EBI_AWS_ENDPOINT_REGION
           value:
+        {{- end }}
         - name: KEY_STORE
           value: "/ega/tls/res.p12"
         - name: KEY_STORE_PASSWORD
@@ -112,6 +114,10 @@ spec:
             mountPath: "/ega/tls"
           - name: ca-cert
             mountPath: "/etc/ssl/certs/java"
+          {{- if eq "FileStorage" .Values.config.data_storage_type }}
+          - name: lega-archive
+            mountPath: /ega/archive
+          {{- end }}
       volumes:
         - name: res-shared-pass
           secret:
@@ -128,3 +134,29 @@ spec:
                 items:
                   - key: cacerts
                     path: cacerts
+      {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+        {{- if and .Values.persistence.enabled .Values.podSecurityPolicy.create }}
+          {{- if .Values.ingest.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.ingest.persistence.existingClaim }}
+          {{- else if (eq "flexVolume" .Values.ingest.persistence.storageClass) }}
+          flexVolume:
+            driver: {{ .Values.ingest.persistence.flexVolume.driver | quote }}
+            fsType: {{ .Values.ingest.persistence.flexVolume.fsType | quote }}
+            options:
+              fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
+              clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
+          {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
+          source:
+            nfs:
+              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
+              readOnly: false
+          {{- end }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.config.data_storage_location | quote }}
+            type: Directory
+        {{- end }}
+      {{- end }}

--- a/ega-charts/localega/templates/res-deploy.yaml
+++ b/ega-charts/localega/templates/res-deploy.yaml
@@ -31,6 +31,18 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         allowPrivilegeEscalation: false
+{{- if .Values.res.coLocateIngest }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: role
+                operator: In
+                values:
+                - ingest
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       containers:
       - name: res
         image: "{{ .Values.res.repository }}:{{ .Values.res.imageTag }}"

--- a/ega-charts/localega/templates/verify-deploy.yaml
+++ b/ega-charts/localega/templates/verify-deploy.yaml
@@ -75,6 +75,10 @@ spec:
           mountPath: /etc/ega/
         - name: tls
           mountPath: /etc/ega/ssl
+        {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+          mountPath: /ega/archive
+        {{- end }}
       volumes:
         - name: tls-certs
           secret:
@@ -89,4 +93,30 @@ spec:
             sources:
             - configMap:
                 name: {{ template "localega.name" . }}-verify-conf
+      {{- if eq "FileStorage" .Values.config.data_storage_type }}
+        - name: lega-archive
+        {{- if and .Values.persistence.enabled .Values.podSecurityPolicy.create }}
+          {{- if .Values.ingest.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.ingest.persistence.existingClaim }}
+          {{- else if (eq "flexVolume" .Values.ingest.persistence.storageClass) }}
+          flexVolume:
+            driver: {{ .Values.ingest.persistence.flexVolume.driver | quote }}
+            fsType: {{ .Values.ingest.persistence.flexVolume.fsType | quote }}
+            options:
+              fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
+              clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
+          {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
+          source:
+            nfs:
+              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
+              readOnly: false
+          {{- end }}
+        {{- else }}
+          hostPath:
+            path: {{ .Values.config.data_storage_location | quote }}
+            type: Directory
+        {{- end }}
+      {{- end }}
       restartPolicy: Always

--- a/ega-charts/localega/templates/verify-deploy.yaml
+++ b/ega-charts/localega/templates/verify-deploy.yaml
@@ -34,6 +34,18 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         allowPrivilegeEscalation: false
+{{- if .Values.verify.coLocateIngest }}
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: role
+                operator: In
+                values:
+                - ingest
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
       initContainers:
       - name: tls-init
         image: busybox

--- a/ega-charts/localega/values.yaml
+++ b/ega-charts/localega/values.yaml
@@ -228,6 +228,18 @@ ingest:
 # If the deployment requires the use of hostPath volumes for the shared filesystem
 # that is used by inbox and ingest, set coLocateInbox: true
   coLocateInbox: false
+  persistence:
+    existingClaim: ""
+    storageSize: 1Gi
+    storageClass: ""
+    flexVolume:
+      driver: "" #ceph.rook.io/rook
+      fsType: "" #ceph
+      fsName: "" #sharedfs
+      clusterNamespace: "" #rook-ceph
+    nfs:
+      server: ""
+      path: ""
 
 keys:
   deploy: true

--- a/ega-charts/localega/values.yaml
+++ b/ega-charts/localega/values.yaml
@@ -334,6 +334,10 @@ res:
   keystorePass: "changeit"
   ingress:
     path: "/res"
+## co-locate verify with res and ingest
+# If the deployment requires the use of local volumes for the shared filesystem
+# that is used by verify, res and ingest, set coLocateIngest: true
+  coLocateIngest: false
 
 verify:
   name: verify
@@ -348,6 +352,10 @@ verify:
     limits:
       memory: "256Mi"
       cpu: "250m"
+## co-locate verify with res and ingest
+# If the deployment requires the use of local volumes for the shared filesystem
+# that is used by verify, res and ingest, set coLocateIngest: true
+  coLocateIngest: false
 
 tester:
   run: false


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
This adds posix based storage backend for Data Archive, available options are NFS, local-PV and flex-volume.
Storage backend is defined in ingest and used by res and verify.
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1) Add option to co-locate verify and res with ingest.
2) Add FileStorage backend to ingest, verify  and res
3) Replaces spring profile `LocalEGA` with `default` for RES when FileStorage backend is in use
3) Prepare e2e-tester for a FileStorage backend

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Fixes #44 
### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
This is wholly untested since the e2e-tester is not designed to work with a non S3 backend.
### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
