### PR TITLE
nfs volume fixes for new kubernetes API

### DIFF
--- a/ega-charts/cega/Chart.yaml
+++ b/ega-charts/cega/Chart.yaml
@@ -7,4 +7,4 @@ maintainers:
 name: cega
 sources:
 - https://github.com/NBISweden/LocalEGA-helm
-version: 0.3.1
+version: 0.3.2

--- a/ega-charts/cega/templates/cegamq-deploy.yaml
+++ b/ega-charts/cega/templates/cegamq-deploy.yaml
@@ -66,8 +66,13 @@ spec:
           defaultMode: 0440
       - name: rabbitmq
       {{- if .Values.persistence.enabled }}
+        {{- if .Values.mq.persistence.existingClaim }}
         persistentVolumeClaim:
-          claimName: {{ template "cega.fullname" . }}-rabbitmq
-      {{ else}}
+          claimName: {{ .Values.mq.persistence.existingClaim }}
+        {{- else }}
+        persistentVolumeClaim:
+          claimName: {{ template "cega.fullname" . }}-rabbit
+        {{ end }}
+      {{- else }}
         emptyDir: {}
       {{ end }}

--- a/ega-charts/localega/templates/e2e-tester.yaml
+++ b/ega-charts/localega/templates/e2e-tester.yaml
@@ -232,11 +232,9 @@ spec:
               fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
               clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
           {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
-          source:
-            nfs:
-              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
-              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
-              readOnly: false
+          nfs:
+            server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+            path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/ega-charts/localega/templates/e2e-tester.yaml
+++ b/ega-charts/localega/templates/e2e-tester.yaml
@@ -27,6 +27,8 @@ data:
       inbox_address: {{ template "localega.name" . }}-inbox
       # Inbox port
       inbox_port: {{ .Values.inbox.service.port }}
+      data_storage_type:  {{ .Values.config.data_storage_type }}
+      data_storage_location: {{ .Values.config.data_storage_location }}
       tls_cert_tester: /conf/tester{{ .Values.config.tls_cert_ending }}
       tls_key_tester: /conf/tester{{ .Values.config.tls_key_ending }}
       tls_ca_root_file: /conf/{{ .Values.config.tls_ca_root_file }}

--- a/ega-charts/localega/templates/e2e-tester.yaml
+++ b/ega-charts/localega/templates/e2e-tester.yaml
@@ -179,7 +179,7 @@ spec:
           mountPath: /volume
       {{- if eq "FileStorage" .Values.config.data_storage_type }}
         - name: lega-archive
-          mountPath: /ega/archive
+          mountPath: {{ .Values.config.data_storage_location | quote }}
       {{- end }}
       restartPolicy: Never
       volumes:

--- a/ega-charts/localega/templates/ingest-deploy.yaml
+++ b/ega-charts/localega/templates/ingest-deploy.yaml
@@ -113,11 +113,9 @@ spec:
             fsName: {{ .Values.inbox.persistence.flexVolume.fsName | quote }}
             clusterNamespace:  {{ .Values.inbox.persistence.flexVolume.clusterNamespace | quote }}
       {{- else if (eq "nfs" .Values.inbox.persistence.storageClass) }}
-        source:
-          nfs:
-            server: {{ if .Values.inbox.persistence.nfs.server }}{{ .Values.inbox.persistence.nfs.server | quote }}{{ end }}
-            path: {{ if .Values.inbox.persistence.nfs.path }}{{ .Values.inbox.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
-            readOnly: false
+        nfs:
+          server: {{ if .Values.inbox.persistence.nfs.server }}{{ .Values.inbox.persistence.nfs.server | quote }}{{ end }}
+          path: {{ if .Values.inbox.persistence.nfs.path }}{{ .Values.inbox.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
       {{- end }}
   {{- if eq "FileStorage" .Values.config.data_storage_type }}
       - name: lega-archive
@@ -132,11 +130,9 @@ spec:
             fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
             clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
       {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
-        source:
-          nfs:
-            server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
-            path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
-            readOnly: false
+        nfs:
+          server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+          path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
       {{- end }}
   {{- end }}
 {{- end }}

--- a/ega-charts/localega/templates/ingest-deploy.yaml
+++ b/ega-charts/localega/templates/ingest-deploy.yaml
@@ -84,7 +84,7 @@ spec:
           mountPath: /etc/ega/
         {{- if eq "FileStorage" .Values.config.data_storage_type }}
         - name: lega-archive
-          mountPath: "/ega/archive"
+          mountPath: {{ .Values.config.data_storage_location | quote }}
         {{- end }}
       restartPolicy: Always
       volumes:

--- a/ega-charts/localega/templates/mina-inbox-deploy.yaml
+++ b/ega-charts/localega/templates/mina-inbox-deploy.yaml
@@ -160,11 +160,9 @@ spec:
               fsName: {{ .Values.inbox.persistence.flexVolume.fsName | quote }}
               clusterNamespace:  {{ .Values.inbox.persistence.flexVolume.clusterNamespace | quote }}
           {{- else if (eq "nfs" .Values.inbox.persistence.storageClass) }}
-          source:
-            nfs:
-              server: {{- if .Values.inbox.persistence.nfs.server }}{{ .Values.inbox.persistence.nfs.server | quote }}{{- end }}
-              path: {{- if .Values.inbox.persistence.nfs.path }}{{ .Values.inbox.persistence.nfs.path | quote }}{{- else }}{{ "/" }}{{- end }}
-              readOnly: false
+          nfs:
+            server: {{ if .Values.inbox.persistence.nfs.server }}{{ .Values.inbox.persistence.nfs.server | quote }}{{ end }}
+            path: {{ if .Values.inbox.persistence.nfs.path }}{{ .Values.inbox.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
           {{- end }}
         {{- end }}
 {{- end }}

--- a/ega-charts/localega/templates/podsecuritypolicy.yaml
+++ b/ega-charts/localega/templates/podsecuritypolicy.yaml
@@ -40,4 +40,5 @@ spec:
   - configMap
   - emptyDir
   - projected
+  - nfs
 {{- end }}

--- a/ega-charts/localega/templates/res-deploy.yaml
+++ b/ega-charts/localega/templates/res-deploy.yaml
@@ -150,11 +150,9 @@ spec:
               fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
               clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
           {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
-          source:
-            nfs:
-              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
-              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
-              readOnly: false
+          nfs:
+            server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+            path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
           {{- end }}
         {{- else }}
           hostPath:
@@ -163,3 +161,4 @@ spec:
         {{- end }}
       {{- end }}
 {{- end }}
+

--- a/ega-charts/localega/templates/res-deploy.yaml
+++ b/ega-charts/localega/templates/res-deploy.yaml
@@ -54,7 +54,7 @@ spec:
 {{ toYaml .Values.res.resources | trim | indent 10 }}
         env:
         - name: SPRING_PROFILES_ACTIVE
-          value: {{ if eq "FileStorage" .Values.config.data_storage_type }} no-oss,default {{ else }} no-oss,LocalEGA {{ end }}
+          value: no-oss,LocalEGA
         - name: FILEDATABASE_SERVERS
           value: "{{- if .Values.filedatabase.deploy }}{{ template "localega.name" . }}-filedatabase:{{ .Values.filedatabase.servicePort }}{{- else }}{{ .Values.config.filedatabase_host }}:{{ .Values.config.filedatabase_port }}{{- end }}"
         - name: KEYS_SERVERS
@@ -118,7 +118,7 @@ spec:
             mountPath: "/etc/ssl/certs/java"
           {{- if eq "FileStorage" .Values.config.data_storage_type }}
           - name: lega-archive
-            mountPath: /ega/archive
+            mountPath: {{ .Values.config.data_storage_location | quote }}
           {{- end }}
       volumes:
         - name: res-shared-pass

--- a/ega-charts/localega/templates/verify-deploy.yaml
+++ b/ega-charts/localega/templates/verify-deploy.yaml
@@ -82,7 +82,7 @@ spec:
           mountPath: /etc/ega/ssl
         {{- if eq "FileStorage" .Values.config.data_storage_type }}
         - name: lega-archive
-          mountPath: /ega/archive
+          mountPath: {{ .Values.config.data_storage_location | quote }}
         {{- end }}
       volumes:
         - name: tls-certs

--- a/ega-charts/localega/templates/verify-deploy.yaml
+++ b/ega-charts/localega/templates/verify-deploy.yaml
@@ -116,11 +116,9 @@ spec:
               fsName: {{ .Values.ingest.persistence.flexVolume.fsName | quote }}
               clusterNamespace:  {{ .Values.ingest.persistence.flexVolume.clusterNamespace | quote }}
           {{- else if (eq "nfs" .Values.ingest.persistence.storageClass) }}
-          source:
-            nfs:
-              server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
-              path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
-              readOnly: false
+          nfs:
+            server: {{ if .Values.ingest.persistence.nfs.server }}{{ .Values.ingest.persistence.nfs.server | quote }}{{ end }}
+            path: {{ if .Values.ingest.persistence.nfs.path }}{{ .Values.ingest.persistence.nfs.path | quote }}{{ else }}{{ "/" }}{{ end }}
           {{- end }}
         {{- else }}
           hostPath:


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix

### Pull request long description:
<!-- Describe your pull request in detail. -->

The NFSVolume API in kubernetes changed and this required some fixes to make it work.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. updated CEGA MQ to work with custom PVC
2. updated e2e tester, Apache Mina inbox, RES, Verify and Ingest with new NFS volume k8s syntax
3. need to update the key in DOA because `LocalEGA-deploy-init` changed I the helm lint failed.